### PR TITLE
Add patterns for Finnish.

### DIFF
--- a/antidelete.py
+++ b/antidelete.py
@@ -119,6 +119,11 @@ if __name__ == '__main__':
         'fn_day': lambda d: 'Wikipedia:Articles_for_deletion/Log/' + d.strftime('%Y_%B_%e'),
         'fn_title': lambda t: t.replace(' (2nd nomination)', ''),
         }
+    patterns['fi'] = {
+        'test': 'oistoäänestys}}',
+        'regexp': '{{/(.*)}}',
+        'title': u'Wikipedia:Poistoäänestykset'
+        }
     patterns['fr'] = {
         'test': 'uppression}}',
         'regexp': '[*]{{L[|](.*)}}',
@@ -129,6 +134,6 @@ if __name__ == '__main__':
         'regexp': '[*]\[\[(.+)\]\]',
         'fn_day': lambda d: "Wikipedia:Te beoordelen pagina's/Toegevoegd " + d.strftime('%Y%m%d')
         }
-    for lang in ['de', 'en', 'nl', 'fr', 'sv']:
+    for lang in ['de', 'en', 'fi', 'nl', 'fr', 'sv']:
         ad = Antidelete(lang, patterns[lang])
         ad.fetch()

--- a/deleted_family.py
+++ b/deleted_family.py
@@ -5,7 +5,7 @@ class Family(family.Family):
     def __init__(self):
         family.Family.__init__(self)
         self.name = 'deleted'
-        langlist = [ 'en', 'fr', 'nl', 'de', 'es', 'it', 'pt', 'sv' ]
+        langlist = [ 'en', 'fr', 'fi', 'nl', 'de', 'es', 'it', 'pt', 'sv' ]
         self.langs = { x: x for x in langlist }
 
     def hostname(self, code):


### PR DESCRIPTION
I'd like to add Finnish wikipedia to the language versions that are covered by Deletionpedia. I've tested that this finds the page currently on the list of active removal votes. Let me know if I need to do anything else and thanks for your work on Deletionpedia!
